### PR TITLE
Better error handling when the page group creation fails

### DIFF
--- a/src/components/Page/EditPageGroup.tsx
+++ b/src/components/Page/EditPageGroup.tsx
@@ -11,6 +11,7 @@ export function EditPageGroup() {
     const [pageGroupId, setPageGroupId] = useState<number>(0);
     const {t} = useTranslation();
     const [loading, setLoading] = useState<boolean>(true);
+    const [submitting, setSubmitting] = useState<boolean>(false);
     const [createNewPageGroup, setCreateNewPageGroup] = useState(false);
     const [sendButtonText, setSendButtonText] = useState(t("EditPageGroup.form.button.update"));
     const [pageGroupForm] = Form.useForm();
@@ -70,11 +71,48 @@ export function EditPageGroup() {
         }
     }, [pageGroupId, paramId, t, languageList]);
 
+    function getErrorMessage(error: unknown): string {
+        if (typeof error === "string") {
+            return error;
+        }
+
+        if (error instanceof Error) {
+            return error.message;
+        }
+
+        if (typeof error === "object" && error !== null) {
+            const maybeError = error as { message?: unknown; response?: { data?: unknown; status?: number } };
+            if (typeof maybeError.message === "string") {
+                return maybeError.message;
+            }
+
+            if (typeof maybeError.response?.data === "string") {
+                return maybeError.response.data;
+            }
+
+            if (typeof maybeError.response?.status === "number") {
+                return `HTTP ${maybeError.response.status}`;
+            }
+        }
+
+        return "Unknown error";
+    }
+
     function onFinish(formData: PageGroupRequest): void {
-        setLoading(true);
+        setSubmitting(true);
+
+        const normalizedFormData: PageGroupRequest = {
+            ...formData,
+            pageGroupVersions: (formData.pageGroupVersions ?? []).map((version, index) => ({
+                id: version.id ?? 0,
+                title: version.title,
+                language: version.language ?? pageGroup.pageGroupVersions[index]?.language ?? languageList[index] ?? "",
+                pageGroupId: version.pageGroupId ?? formData.id ?? pageGroupId ?? 0,
+            })),
+        };
 
         if (createNewPageGroup) {
-            pageGroupMgmtAPI.create(formData)
+            pageGroupMgmtAPI.create(normalizedFormData)
                     .then((response: PageGroupResponse) => {
                         // If we get back an ID, we assume the creation was successful
                         if (response && response.id > 0) {
@@ -82,15 +120,15 @@ export function EditPageGroup() {
                         } else {
                             messageApi.error(t("EditPageGroup.onFinish.create.fail"));
                         }
-                        setLoading(false);
+                        setSubmitting(false);
                     })
-                    .catch(e => {
+                    .catch((e: unknown) => {
                         console.error(e);
-                        messageApi.error(e);
-                        setLoading(false);
+                        messageApi.error(`${t("EditPageGroup.onFinish.create.fail")} ${getErrorMessage(e)}`);
+                        setSubmitting(false);
                     });
         } else {
-            pageGroupMgmtAPI.update(formData)
+            pageGroupMgmtAPI.update(normalizedFormData)
                     .then((response: PageGroupResponse) => {
                         // If we get back the same ID as we sent, we assume the update was successful
                         if (response && response.id === pageGroupId) {
@@ -98,12 +136,12 @@ export function EditPageGroup() {
                         } else {
                             messageApi.error(t("EditPageGroup.onFinish.update.fail"));
                         }
-                        setLoading(false);
+                        setSubmitting(false);
                     })
-                    .catch(e => {
+                    .catch((e: unknown) => {
                         console.error(e);
-                        messageApi.error(e);
-                        setLoading(false);
+                        messageApi.error(`${t("EditPageGroup.onFinish.update.fail")} ${getErrorMessage(e)}`);
+                        setSubmitting(false);
                     });
         }
     }
@@ -115,7 +153,7 @@ export function EditPageGroup() {
     return (
             <div className={"darkDiv"}>
                 {contextHolder}
-                <Spin spinning={loading}>
+                <Spin spinning={loading || submitting}>
                     {!loading && <Form
                             form={pageGroupForm}
                             labelCol={{span: 8}}
@@ -143,13 +181,15 @@ export function EditPageGroup() {
                             {(groupVersions, {add: _add, remove: _remove}) => {
                                 return (
                                         <>
-                                            {groupVersions.map((_pageGroupVersion, index) => {
-                                                const uniqueKey = `pageGroupDivider${index}${pageGroup.pageGroupVersions[index].language}`;
+                                            {groupVersions.map((groupVersion) => {
+                                                const language = pageGroupForm.getFieldValue(["pageGroupVersions", groupVersion.name, "language"]) ??
+                                                        pageGroup.pageGroupVersions[groupVersion.name]?.language ?? "";
+                                                const uniqueKey = `pageGroupDivider${groupVersion.key}${language}`;
                                                 return (<div key={uniqueKey}>
                                                     <Divider titlePlacement={"left"} orientation={"horizontal"}
-                                                             key={uniqueKey + "-divider"}>{pageGroup.pageGroupVersions[index].language.toUpperCase()}</Divider>
+                                                             key={uniqueKey + "-divider"}>{language.toUpperCase()}</Divider>
                                                     <Form.Item
-                                                            name={[index, "id"]}
+                                                            name={[groupVersion.name, "id"]}
                                                             label={"ID"}
                                                             key={uniqueKey + "-id"}
                                                             hidden={true}
@@ -157,7 +197,21 @@ export function EditPageGroup() {
                                                         <Input type={"text"} disabled={true} key={uniqueKey + "-id-input"}/>
                                                     </Form.Item>
                                                     <Form.Item
-                                                            name={[index, "title"]}
+                                                            name={[groupVersion.name, "language"]}
+                                                            key={uniqueKey + "-language"}
+                                                            hidden={true}
+                                                    >
+                                                        <Input type={"text"} key={uniqueKey + "-language-input"}/>
+                                                    </Form.Item>
+                                                    <Form.Item
+                                                            name={[groupVersion.name, "pageGroupId"]}
+                                                            key={uniqueKey + "-page-group-id"}
+                                                            hidden={true}
+                                                    >
+                                                        <Input type={"text"} key={uniqueKey + "-page-group-id-input"}/>
+                                                    </Form.Item>
+                                                    <Form.Item
+                                                            name={[groupVersion.name, "title"]}
                                                             label={t("EditPageGroup.form.pageGroupVersions.label")}
                                                             key={uniqueKey + "-title"}
                                                             tooltip={t("EditPageGroup.form.pageGroupVersions.tooltip")}
@@ -204,14 +258,14 @@ export function EditPageGroup() {
                             <Button
                                     type={"primary"}
                                     htmlType={"submit"}
-                                    disabled={loading}
+                                    disabled={loading || submitting}
                             >
                                 {sendButtonText}
                             </Button>
                             <Button
                                     type={"default"}
                                     htmlType={"reset"}
-                                    disabled={loading}
+                                    disabled={loading || submitting}
                             >{t("common.button.reset")}</Button>
                         </Form.Item>
                     </Form>}


### PR DESCRIPTION
This pull request refactors the `EditPageGroup` component to improve error handling, form data normalization, and UI responsiveness during API operations. The changes ensure that the form displays more accurate loading states, provides clearer error messages, and correctly handles dynamic fields for page group versions.

Error handling and feedback improvements:

* Added a `getErrorMessage` helper function to extract and display more informative error messages from API failures in the `onFinish` handler, improving user feedback.
* Updated error handling in API calls to use the new helper function and show localized error messages to the user.

Form submission and loading state enhancements:

* Introduced a separate `submitting` state to distinguish between initial loading and form submission, and updated UI elements (`Spin`, buttons) to reflect both states for better user experience. [[1]](diffhunk://#diff-7b0385047b336e7ef5d7ee8432c92b0274dd577ab290b05d9718178f5ff57b4aR14) [[2]](diffhunk://#diff-7b0385047b336e7ef5d7ee8432c92b0274dd577ab290b05d9718178f5ff57b4aL118-R156) [[3]](diffhunk://#diff-7b0385047b336e7ef5d7ee8432c92b0274dd577ab290b05d9718178f5ff57b4aL207-R268)

Page group versions normalization and dynamic fields:

* Normalized `pageGroupVersions` data before API calls to ensure all required fields are present, reducing potential backend errors.
* Refactored dynamic form rendering to use field values for keys and language display, and added hidden fields for `language` and `pageGroupId` to support more flexible editing of page group versions.