### PR TITLE
230 allow operatorsadmins to send notifications to various diver groups

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -117,12 +117,32 @@
   "AdminNotifications" : {
     "error" : "Benachrichtigungen konnten nicht gesendet werden",
     "errorGetUsers" : "Benutzer konnten nicht abgerufen werden",
+    "errorNoGroup" : "Bitte wählen Sie eine Benachrichtigungsgruppe",
+    "errorNoInactiveDays" : "Bitte geben Sie die Anzahl der Tage für die Auswahl inaktiver Benutzer an",
     "errorNoRecipients" : "Bitte wählen Sie mindestens einen Empfänger aus oder aktivieren Sie 'An alle Benutzer senden'",
     "form" : {
+      "inactiveDays" : {
+        "label" : "Tage der Inaktivität",
+        "min" : "Tage müssen mindestens 1 sein",
+        "placeholder" : "Geben Sie die Anzahl der Tage ein",
+        "required" : "Bitte geben Sie die Anzahl der Tage ein"
+      },
       "message" : {
         "label" : "Nachricht",
+        "min" : "Nachricht muss mindestens 5 Zeichen lang sein",
         "placeholder" : "Geben Sie die Benachrichtigungsnachricht ein",
         "required" : "Bitte geben Sie eine Nachricht ein"
+      },
+      "notificationGroup" : {
+        "label" : "Benachrichtigungsgruppe wählen",
+        "placeholder" : "Wählen Sie eine Benutzergruppe",
+        "required" : "Bitte wählen Sie eine Benachrichtigungsgruppe"
+      },
+      "notificationMode" : {
+        "group" : "Benachrichtigungsgruppe",
+        "label" : "Benachrichtigungsverteilungsmethode",
+        "recipients" : "Bestimmte Benutzer auswählen",
+        "sendAll" : "An alle Benutzer senden"
       },
       "recipients" : {
         "label" : "Empfänger",
@@ -130,15 +150,20 @@
         "required" : "Bitte wählen Sie mindestens einen Empfänger"
       },
       "reset" : "Zurücksetzen",
-      "sendAll" : {
-        "label" : "An alle Benutzer senden"
-      },
       "submit" : "Benachrichtigung senden",
       "title" : {
         "label" : "Titel",
         "placeholder" : "Benachrichtigungstitel eingeben",
         "required" : "Bitte geben Sie einen Titel ein"
       }
+    },
+    "groups" : {
+      "active_membership" : "Benutzer mit aktiver Mitgliedschaft",
+      "all_registered" : "Alle registrierten Benutzer",
+      "inactive_days" : "Benutzer inaktiv für angegebene Tage",
+      "locked_accounts" : "Benutzer mit gesperrten Konten",
+      "never_had_membership" : "Hatten nie eine Mitgliedschaft",
+      "no_active_membership" : "Benutzer ohne aktive Mitgliedschaft"
     },
     "participantCount" : "Benachrichtigung an {{count}} Teilnehmer senden",
     "success" : "Benachrichtigungen erfolgreich gesendet",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -117,13 +117,32 @@
   "AdminNotifications" : {
     "error" : "Failed to send notifications",
     "errorGetUsers" : "Failed to get users",
+    "errorNoGroup" : "Please select a notification group",
+    "errorNoInactiveDays" : "Please enter the number of days for inactive user selection",
     "errorNoRecipients" : "Please select at least one recipient or check 'Send to all users'",
     "form" : {
+      "inactiveDays" : {
+        "label" : "Days of inactivity",
+        "min" : "Days must be at least 1",
+        "placeholder" : "Enter number of days",
+        "required" : "Please enter the number of days"
+      },
       "message" : {
         "label" : "Message",
         "min" : "Message must be at least 5 characters",
         "placeholder" : "Enter the notification message",
         "required" : "Please enter a message"
+      },
+      "notificationGroup" : {
+        "label" : "Select notification group",
+        "placeholder" : "Choose a user group",
+        "required" : "Please select a notification group"
+      },
+      "notificationMode" : {
+        "group" : "Notification group",
+        "label" : "Notification delivery method",
+        "recipients" : "Select specific users",
+        "sendAll" : "Send to all users"
       },
       "recipients" : {
         "label" : "Recipients",
@@ -131,15 +150,20 @@
         "required" : "Please select at least one recipient"
       },
       "reset" : "Reset",
-      "sendAll" : {
-        "label" : "Send to all users"
-      },
       "submit" : "Send Notification",
       "title" : {
         "label" : "Title",
         "placeholder" : "Enter notification title",
         "required" : "Please enter a title"
       }
+    },
+    "groups" : {
+      "active_membership" : "Users with active membership",
+      "all_registered" : "All registered users",
+      "inactive_days" : "Users inactive for specified days",
+      "locked_accounts" : "Users with locked accounts",
+      "never_had_membership" : "Never had membership",
+      "no_active_membership" : "Users without active membership"
     },
     "participantCount" : "Sending notification to {{count}} participant(s)",
     "success" : "Notifications sent successfully",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -117,12 +117,32 @@
   "AdminNotifications" : {
     "error" : "Error al enviar notificaciones",
     "errorGetUsers" : "Error al obtener usuarios",
+    "errorNoGroup" : "Seleccione un grupo de notificaciones",
+    "errorNoInactiveDays" : "Ingrese el número de días para la selección de usuarios inactivos",
     "errorNoRecipients" : "Seleccione al menos un destinatario o marque 'Enviar a todos los usuarios'",
     "form" : {
+      "inactiveDays" : {
+        "label" : "Días de inactividad",
+        "min" : "Los días deben ser al menos 1",
+        "placeholder" : "Ingrese la cantidad de días",
+        "required" : "Ingrese la cantidad de días"
+      },
       "message" : {
         "label" : "Mensaje",
+        "min" : "El mensaje debe tener al menos 5 caracteres",
         "placeholder" : "Ingrese el mensaje de notificación",
         "required" : "Ingrese un mensaje"
+      },
+      "notificationGroup" : {
+        "label" : "Seleccione grupo de notificaciones",
+        "placeholder" : "Seleccione un grupo de usuarios",
+        "required" : "Seleccione un grupo de notificaciones"
+      },
+      "notificationMode" : {
+        "group" : "Grupo de notificaciones",
+        "label" : "Método de entrega de notificaciones",
+        "recipients" : "Seleccione usuarios específicos",
+        "sendAll" : "Enviar a todos los usuarios"
       },
       "recipients" : {
         "label" : "Destinatarios",
@@ -130,15 +150,20 @@
         "required" : "Seleccione al menos un destinatario"
       },
       "reset" : "Restablecer",
-      "sendAll" : {
-        "label" : "Enviar a todos los usuarios"
-      },
       "submit" : "Enviar notificación",
       "title" : {
         "label" : "Título",
         "placeholder" : "Ingrese el título de la notificación",
         "required" : "Ingrese un título"
       }
+    },
+    "groups" : {
+      "active_membership" : "Usuarios con membresía activa",
+      "all_registered" : "Todos los usuarios registrados",
+      "inactive_days" : "Usuarios inactivos durante días especificados",
+      "locked_accounts" : "Usuarios con cuentas bloqueadas",
+      "never_had_membership" : "Nunca tuvo membresía",
+      "no_active_membership" : "Usuarios sin membresía activa"
     },
     "participantCount" : "Enviar notificación a {{count}} participante(s)",
     "success" : "Notificaciones enviadas correctamente",

--- a/public/locales/fi.json
+++ b/public/locales/fi.json
@@ -117,12 +117,32 @@
   "AdminNotifications" : {
     "error" : "Ilmoitusten lähettäminen epäonnistui",
     "errorGetUsers" : "Käyttäjien hakeminen epäonnistui",
+    "errorNoGroup" : "Valitse ilmoitusryhmä",
+    "errorNoInactiveDays" : "Syötä päivien määrä passiivisten käyttäjien valinnalle",
     "errorNoRecipients" : "Valitse vähintään yksi vastaanottaja tai valitse 'Lähetä kaikille käyttäjille'",
     "form" : {
+      "inactiveDays" : {
+        "label" : "Päiviä inaktiivisuutta",
+        "min" : "Päivien on oltava vähintään 1",
+        "placeholder" : "Syötä päivien määrä",
+        "required" : "Syötä päivien määrä"
+      },
       "message" : {
         "label" : "Viesti",
+        "min" : "Viesti on oltava vähintään 5 merkkiä",
         "placeholder" : "Syötä ilmoituksen viesti",
         "required" : "Syötä viesti"
+      },
+      "notificationGroup" : {
+        "label" : "Valitse ilmoitusryhmä",
+        "placeholder" : "Valitse käyttäjäryhmä",
+        "required" : "Valitse ilmoitusryhmä"
+      },
+      "notificationMode" : {
+        "group" : "Ilmoitusryhmä",
+        "label" : "Ilmoituksen toimittotapa",
+        "recipients" : "Valitse tietyt käyttäjät",
+        "sendAll" : "Lähetä kaikille käyttäjille"
       },
       "recipients" : {
         "label" : "Vastaanottajat",
@@ -130,15 +150,20 @@
         "required" : "Valitse vähintään yksi vastaanottaja"
       },
       "reset" : "Tyhjennä",
-      "sendAll" : {
-        "label" : "Lähetä kaikille käyttäjille"
-      },
       "submit" : "Lähetä ilmoitus",
       "title" : {
         "label" : "Otsikko",
         "placeholder" : "Syötä ilmoituksen otsikko",
         "required" : "Syötä otsikko"
       }
+    },
+    "groups" : {
+      "active_membership" : "Käyttäjät, joilla on aktiivinen jäsenyys",
+      "all_registered" : "Kaikki rekisteröidyt käyttäjät",
+      "inactive_days" : "Käyttäjät, jotka ovat olleet passiivisia määritettyjen päivien ajan",
+      "locked_accounts" : "Käyttäjät, joilla on lukitut tilit",
+      "never_had_membership" : "Ei koskaan ollut jäsenyyttä",
+      "no_active_membership" : "Käyttäjät, joilla ei ole aktiivista jäsenyyttä"
     },
     "participantCount" : "Lähetetään ilmoitus {{count}} osallistujalle",
     "success" : "Ilmoitukset lähetetty onnistuneesti",

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -117,12 +117,32 @@
   "AdminNotifications" : {
     "error" : "Misslyckades med att skicka aviseringar",
     "errorGetUsers" : "Misslyckades med att hämta användare",
+    "errorNoGroup" : "Välj en aviseringsgrupp",
+    "errorNoInactiveDays" : "Ange antal dagar för inaktiv användarvalare",
     "errorNoRecipients" : "Välj minst en mottagare eller markera 'Skicka till alla användare'",
     "form" : {
+      "inactiveDays" : {
+        "label" : "Dagar av inaktivitet",
+        "min" : "Dagar måste vara minst 1",
+        "placeholder" : "Ange antal dagar",
+        "required" : "Ange antal dagar"
+      },
       "message" : {
         "label" : "Meddelande",
+        "min" : "Meddelandet måste vara minst 5 tecken",
         "placeholder" : "Ange aviseringsmeddelandet",
         "required" : "Ange ett meddelande"
+      },
+      "notificationGroup" : {
+        "label" : "Välj aviseringsgrupp",
+        "placeholder" : "Välj en användargrupp",
+        "required" : "Välj en aviseringsgrupp"
+      },
+      "notificationMode" : {
+        "group" : "Aviseringsgrupp",
+        "label" : "Aviseringsleveransmetod",
+        "recipients" : "Välj specifika användare",
+        "sendAll" : "Skicka till alla användare"
       },
       "recipients" : {
         "label" : "Mottagare",
@@ -130,15 +150,20 @@
         "required" : "Välj minst en mottagare"
       },
       "reset" : "Återställ",
-      "sendAll" : {
-        "label" : "Skicka till alla användare"
-      },
       "submit" : "Skicka avisering",
       "title" : {
         "label" : "Titel",
         "placeholder" : "Ange aviseringstitel",
         "required" : "Ange en titel"
       }
+    },
+    "groups" : {
+      "active_membership" : "Användare med aktiva medlemskap",
+      "all_registered" : "Alla registrerade användare",
+      "inactive_days" : "Användare inaktiva i angivna dagar",
+      "locked_accounts" : "Användare med låsta konton",
+      "never_had_membership" : "Aldrig haft medlemskap",
+      "no_active_membership" : "Användare utan aktivt medlemskap"
     },
     "participantCount" : "Skickar avisering till {{count}} deltagare",
     "success" : "Aviseringar skickade",

--- a/src/__tests__/components.EditDiveEventValidation.test.ts
+++ b/src/__tests__/components.EditDiveEventValidation.test.ts
@@ -1,4 +1,12 @@
-import {exceedsMaxParticipants, isMaxParticipantsTooLow} from "../components/DiveEvent/editDiveEventValidation";
+import dayjs from "dayjs";
+import {
+    buildParticipantOptions,
+    exceedsMaxParticipants,
+    hasValidPaymentForEvent,
+    isMaxParticipantsTooLow
+} from "../components/DiveEvent/editDiveEventValidation";
+import type {ListUserResponse} from "../models";
+import {PaymentTypeEnum, UserTypeEnum} from "../models";
 
 describe("EditDiveEvent participant max validation", () => {
     it("allows count at max limit", () => {
@@ -17,3 +25,264 @@ describe("EditDiveEvent participant max validation", () => {
         expect(isMaxParticipantsTooLow(4, 3)).toBe(true);
     });
 });
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const futureDate = dayjs().add(1, "year");
+const pastDate = dayjs().subtract(1, "year");
+
+function makeUser(overrides: Partial<ListUserResponse> = {}): ListUserResponse {
+    return {
+        id: 1,
+        name: "Doe Jane",
+        eventDiveCount: 0,
+        createdAt: dayjs(),
+        payments: [],
+        membershipActive: false,
+        userType: UserTypeEnum.SCUBA_DIVER,
+        tags: [],
+        ...overrides,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// hasValidPaymentForEvent
+// ---------------------------------------------------------------------------
+describe("hasValidPaymentForEvent", () => {
+    const eventId = 240;
+
+    it("returns false when user has no payments", () => {
+        expect(hasValidPaymentForEvent(makeUser({payments: []}), eventId)).toBe(false);
+    });
+
+    it("returns true for a PERIODICAL payment with future end date", () => {
+        const user = makeUser({
+            payments: [{
+                id: 1, userId: 1,
+                paymentType: PaymentTypeEnum.PERIODICAL,
+                paymentCount: 0,
+                startDate: pastDate,
+                endDate: futureDate,
+                created: pastDate,
+                boundEvents: null,
+            }],
+        });
+        expect(hasValidPaymentForEvent(user, eventId)).toBe(true);
+    });
+
+    it("returns false for a PERIODICAL payment with past end date", () => {
+        const user = makeUser({
+            payments: [{
+                id: 1, userId: 1,
+                paymentType: PaymentTypeEnum.PERIODICAL,
+                paymentCount: 0,
+                startDate: pastDate,
+                endDate: pastDate,
+                created: pastDate,
+                boundEvents: null,
+            }],
+        });
+        expect(hasValidPaymentForEvent(user, eventId)).toBe(false);
+    });
+
+    it("returns true for ONE_TIME payment with null end date and positive paymentCount", () => {
+        const user = makeUser({
+            payments: [{
+                id: 1, userId: 1,
+                paymentType: PaymentTypeEnum.ONE_TIME,
+                paymentCount: 1,
+                startDate: pastDate,
+                endDate: dayjs().add(1, "day"),
+                created: pastDate,
+                boundEvents: null,
+            }],
+        });
+        expect(hasValidPaymentForEvent(user, eventId)).toBe(true);
+    });
+
+    it("does not throw when boundEvents is null and paymentCount is 0", () => {
+        const user = makeUser({
+            payments: [{
+                id: 1, userId: 1,
+                paymentType: PaymentTypeEnum.ONE_TIME,
+                paymentCount: 0,
+                startDate: pastDate,
+                endDate: dayjs().add(1, "day").add(1, "day"),
+                created: pastDate,
+                boundEvents: null,
+            }],
+        });
+        expect(() => hasValidPaymentForEvent(user, eventId)).not.toThrow();
+        expect(hasValidPaymentForEvent(user, eventId)).toBe(false);
+    });
+
+    it("returns true for ONE_TIME payment when event is in boundEvents and paymentCount is 0", () => {
+        const user = makeUser({
+            payments: [{
+                id: 1, userId: 1,
+                paymentType: PaymentTypeEnum.ONE_TIME,
+                paymentCount: 0,
+                startDate: pastDate,
+                endDate: dayjs().add(1, "day"),
+                created: pastDate,
+                boundEvents: [eventId, 999],
+            }],
+        });
+        expect(hasValidPaymentForEvent(user, eventId)).toBe(true);
+    });
+
+    it("returns false for ONE_TIME payment when boundEvents does not include event and paymentCount is 0", () => {
+        const user = makeUser({
+            payments: [{
+                id: 1, userId: 1,
+                paymentType: PaymentTypeEnum.ONE_TIME,
+                paymentCount: 0,
+                startDate: pastDate,
+                endDate: dayjs().add(1, "day"),
+                created: pastDate,
+                boundEvents: [999],
+            }],
+        });
+        expect(hasValidPaymentForEvent(user, eventId)).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// buildParticipantOptions — label format, filtering, and regression cases
+// ---------------------------------------------------------------------------
+describe("buildParticipantOptions", () => {
+    const eventId = 240;
+
+    // Mirrors real API responses: only a combined "name" field, no separate firstName/lastName.
+    const aksitKubra = makeUser({
+        id: 450,
+        name: "Akşit Kübra",
+        payments: [{
+            id: 751, userId: 450,
+            paymentType: PaymentTypeEnum.ONE_TIME,
+            paymentCount: 1,
+            startDate: pastDate,
+            endDate: dayjs().add(1, "day"),
+            created: pastDate,
+            boundEvents: null,
+        }],
+        membershipActive: false,
+    });
+
+    // Participant with exhausted payments: paymentCount=0, boundEvents=null.
+    // Would be filtered out by payment logic alone, but is already enrolled.
+    const almeidaTejas = makeUser({
+        id: 243,
+        name: "Almeida Tejas",
+        payments: [
+            {
+                id: 670,
+                userId: 243,
+                paymentType: PaymentTypeEnum.ONE_TIME,
+                paymentCount: 0,
+                startDate: pastDate,
+                endDate: dayjs().add(1, "day"),
+                created: pastDate,
+                boundEvents: null
+            },
+            {
+                id: 380,
+                userId: 243,
+                paymentType: PaymentTypeEnum.ONE_TIME,
+                paymentCount: 0,
+                startDate: pastDate,
+                endDate: dayjs().add(1, "day"),
+                created: pastDate,
+                boundEvents: null
+            },
+        ],
+        membershipActive: false,
+    });
+
+    // --- Label format ---
+
+    it("formats the label as 'name (id)'", () => {
+        const options = buildParticipantOptions([aksitKubra], eventId, false, false);
+        expect(options).toHaveLength(1);
+        expect(options[0].label).toBe("Akşit Kübra (450)");
+    });
+
+    it("does NOT produce 'undefined undefined (id)' when the DTO has only a name field", () => {
+        // Regression guard: adding firstName/lastName to the interface would cause
+        // "undefined undefined (id)" if the backend does not return those fields.
+        const options = buildParticipantOptions([aksitKubra], eventId, false, false);
+        expect(options[0].label).not.toMatch(/undefined/);
+    });
+
+    it("includes the user id in the label", () => {
+        const options = buildParticipantOptions([aksitKubra], eventId, false, false);
+        expect(options[0].label).toContain("(450)");
+    });
+
+    // --- Always-include current participants (core regression) ---
+
+    it("always includes current participants even when they fail the payment filter (regression)", () => {
+        // almeidaTejas: paymentCount=0 + boundEvents=null → normally excluded.
+        const options = buildParticipantOptions(
+            [aksitKubra, almeidaTejas],
+            eventId,
+            false,
+            false,
+            [almeidaTejas]
+        );
+        expect(options.map(o => o.value)).toContain(243);
+        expect(options.map(o => o.value)).toContain(450);
+    });
+
+    it("always includes current participants even when membership is required and they are inactive (regression)", () => {
+        // Both users have membershipActive=false. With requiresMembership=true the filter
+        // removes everyone — but enrolled participants must still appear in options.
+        const options = buildParticipantOptions(
+            [aksitKubra, almeidaTejas],
+            eventId,
+            true,
+            false,
+            [aksitKubra, almeidaTejas]
+        );
+        expect(options.map(o => o.value)).toContain(450);
+        expect(options.map(o => o.value)).toContain(243);
+    });
+
+    it("current participants added via currentParticipants also use 'name (id)' label format", () => {
+        const options = buildParticipantOptions([], eventId, false, false, [almeidaTejas]);
+        expect(options).toHaveLength(1);
+        expect(options[0].label).toBe("Almeida Tejas (243)");
+        expect(options[0].label).not.toMatch(/undefined/);
+    });
+
+    it("does not duplicate a participant who appears in both users and currentParticipants", () => {
+        const options = buildParticipantOptions(
+            [aksitKubra],
+            eventId,
+            false,
+            false,
+            [aksitKubra]
+        );
+        expect(options.filter(o => o.value === 450)).toHaveLength(1);
+    });
+
+    // --- Filtering of non-enrolled users ---
+
+    it("excludes non-enrolled users who lack active membership when membership is required", () => {
+        const options = buildParticipantOptions([aksitKubra], eventId, true, false);
+        expect(options).toHaveLength(0);
+    });
+
+    it("excludes non-enrolled users with no payments when active payment is required", () => {
+        const userNoPayments = makeUser({id: 9, name: "Payments None", payments: []});
+        const options = buildParticipantOptions([userNoPayments], eventId, false, true);
+        expect(options).toHaveLength(0);
+    });
+
+    it("returns empty array for empty user list and no current participants", () => {
+        expect(buildParticipantOptions([], eventId, false, false)).toHaveLength(0);
+    });
+});
+
+

--- a/src/__tests__/services.NotificationAPI.test.ts
+++ b/src/__tests__/services.NotificationAPI.test.ts
@@ -1,9 +1,10 @@
 /// <reference types="jest" />
 import {notificationAPI} from '../services';
 import MockAdapter from 'axios-mock-adapter';
-import type {MarkReadRequest, MessageRequest} from '../models';
+import type {MessageRequest} from '../models';
+import {NotificationGroupEnum, UpdateStatusEnum} from '../models';
 
-describe('NotificationAPI', () => {
+describe('NotificationAPI - Group Notifications', () => {
     let mock: MockAdapter;
 
     beforeEach(() => {
@@ -14,82 +15,269 @@ describe('NotificationAPI', () => {
         mock.reset();
     });
 
-    it('should get unread notifications', async () => {
-        const mockResponse = [{id: 1, read: false, message: 'Notification 1'}];
-        mock.onGet('/unread').reply(200, mockResponse);
-
-        const result = await notificationAPI.getUnreadNotifications();
-        expect(result).toEqual(mockResponse);
-    });
-
-    it('should get all notifications', async () => {
-        const mockResponse = [
-            {id: 1, read: false, message: 'Notification 1'},
-            {id: 2, read: true, message: 'Notification 2'}
-        ];
-        mock.onGet('/all').reply(200, mockResponse);
-
-        const result = await notificationAPI.getAllNotifications();
-        expect(result).toEqual(mockResponse);
-    });
-
-    it('should mark notifications as read', async () => {
-        const markReadRequest = {notificationIds: [1, 2]} as unknown as MarkReadRequest;
-        const mockResponse = {status: 'SUCCESS'};
-        mock.onPost('/mark-read', markReadRequest).reply(200, mockResponse);
-
-        const result = await notificationAPI.markNotificationsAsRead(markReadRequest);
-        expect(result).toEqual(mockResponse);
-    });
-
-    it('should create notification', async () => {
-        const messageRequest = {title: 'New Notification', message: 'Test message'} as unknown as MessageRequest;
-        const mockResponse = {id: 1, title: 'New Notification', message: 'Test message'};
-        mock.onPost('/create', messageRequest).reply(200, mockResponse);
-
-        const result = await notificationAPI.createNotification(messageRequest);
-        expect(result).toEqual(mockResponse);
-    });
-
-    it('should create bulk notifications', async () => {
-        const messageRequest = {title: 'Bulk Notification', message: 'Test message'} as unknown as MessageRequest;
-        const mockResponse = {status: 'SUCCESS'};
-        mock.onPost('/create-bulk', messageRequest).reply(200, mockResponse);
+    test('sends bulk notification with group targeting', async () => {
+        const messageRequest: MessageRequest = {
+            id: 0,
+            title: 'Test Title',
+            message: 'Test Message',
+            description: 'Test Description',
+            creator: 1,
+            notificationGroup: NotificationGroupEnum.ACTIVE_MEMBERSHIP,
+            inactiveDays: undefined
+        };
+        const mockResponse = {status: UpdateStatusEnum.OK, message: 'Notification sent to 5 users'};
+        mock.onPost('/create-bulk').reply(200, mockResponse);
 
         const result = await notificationAPI.createBulkNotifications(messageRequest);
-        expect(result).toEqual(mockResponse);
+
+        expect(mock.history.post).toHaveLength(1);
+        expect(JSON.parse(mock.history.post[0].data)).toMatchObject({
+            notificationGroup: NotificationGroupEnum.ACTIVE_MEMBERSHIP
+        });
+        expect(result.status).toBe(UpdateStatusEnum.OK);
     });
 
-    it('should find all notifications', async () => {
-        const mockResponse = [{id: 1, read: false, message: 'Notification 1'}];
-        mock.onGet('').reply(200, mockResponse);
+    test('sends bulk notification with inactive days group', async () => {
+        const messageRequest: MessageRequest = {
+            id: 0,
+            title: 'Inactive Users',
+            message: 'Please log in',
+            description: 'Reminder for inactive users',
+            creator: 1,
+            notificationGroup: NotificationGroupEnum.INACTIVE_DAYS,
+            inactiveDays: 30
+        };
+        const mockResponse = {status: UpdateStatusEnum.OK, message: 'Notification sent to 12 inactive users'};
+        mock.onPost('/create-bulk').reply(200, mockResponse);
 
-        const result = await notificationAPI.findAll();
-        expect(result).toEqual(mockResponse);
+        const result = await notificationAPI.createBulkNotifications(messageRequest);
+
+        expect(JSON.parse(mock.history.post[0].data)).toMatchObject({
+            notificationGroup: NotificationGroupEnum.INACTIVE_DAYS,
+            inactiveDays: 30
+        });
+        expect(result.status).toBe(UpdateStatusEnum.OK);
     });
 
-    it('should create notification via abstract api', async () => {
-        const payload = {title: 'Test', message: 'Message'} as unknown as MessageRequest;
-        const mockResponse = {id: 1, title: 'Test', message: 'Message'};
-        mock.onPost('', payload).reply(200, mockResponse);
+    test('sends bulk notification with locked accounts group', async () => {
+        const messageRequest: MessageRequest = {
+            id: 0,
+            title: 'Account Locked',
+            message: 'Your account is locked',
+            description: 'Notification for locked accounts',
+            creator: 1,
+            notificationGroup: NotificationGroupEnum.LOCKED_ACCOUNTS
+        };
+        mock.onPost('/create-bulk').reply(200, {status: UpdateStatusEnum.OK, message: 'Sent to 2 locked accounts'});
 
-        const result = await notificationAPI.create(payload);
-        expect(result).toEqual(mockResponse);
+        const result = await notificationAPI.createBulkNotifications(messageRequest);
+
+        expect(mock.history.post).toHaveLength(1);
+        expect(result.status).toBe(UpdateStatusEnum.OK);
     });
 
-    it('should update notification', async () => {
-        const payload = {id: 1, read: true, message: 'Updated'} as unknown as MessageRequest;
-        const mockResponse = {id: 1, read: true, message: 'Updated'};
-        mock.onPut('', payload).reply(200, mockResponse);
+    test('sends bulk notification with no active membership group', async () => {
+        const messageRequest: MessageRequest = {
+            id: 0,
+            title: 'Membership Offer',
+            message: 'Interested in becoming a member?',
+            description: 'Offer for non-members',
+            creator: 1,
+            notificationGroup: NotificationGroupEnum.NO_ACTIVE_MEMBERSHIP
+        };
+        mock.onPost('/create-bulk').reply(200, {status: UpdateStatusEnum.OK, message: 'Sent to 8 non-members'});
 
-        const result = await notificationAPI.update(payload);
-        expect(result).toEqual(mockResponse);
+        const result = await notificationAPI.createBulkNotifications(messageRequest);
+
+        expect(JSON.parse(mock.history.post[0].data)).toMatchObject({
+            notificationGroup: NotificationGroupEnum.NO_ACTIVE_MEMBERSHIP
+        });
+        expect(result.status).toBe(UpdateStatusEnum.OK);
     });
 
-    it('should delete notification', async () => {
-        mock.onDelete('/1').reply(204);
-        await notificationAPI.delete(1);
-        expect(mock.history.delete).toHaveLength(1);
+    test('sends bulk notification with never had membership group', async () => {
+        const messageRequest: MessageRequest = {
+            id: 0,
+            title: 'Join Our Community',
+            message: 'Become a member today',
+            description: 'Invitation for new members',
+            creator: 1,
+            notificationGroup: NotificationGroupEnum.NEVER_HAD_MEMBERSHIP
+        };
+        mock.onPost('/create-bulk').reply(200, {status: UpdateStatusEnum.OK, message: 'Sent to 15 potential members'});
+
+        const result = await notificationAPI.createBulkNotifications(messageRequest);
+
+        expect(JSON.parse(mock.history.post[0].data)).toMatchObject({
+            notificationGroup: NotificationGroupEnum.NEVER_HAD_MEMBERSHIP
+        });
+        expect(result.status).toBe(UpdateStatusEnum.OK);
+    });
+
+    test('handles failed group notification request', async () => {
+        const messageRequest: MessageRequest = {
+            id: 0,
+            title: 'Test',
+            message: 'Test',
+            description: 'Test',
+            creator: 1,
+            notificationGroup: NotificationGroupEnum.ACTIVE_MEMBERSHIP
+        };
+        mock.onPost('/create-bulk').networkError();
+
+        await expect(notificationAPI.createBulkNotifications(messageRequest)).rejects.toThrow();
+    });
+
+    test('sends notification with all parameters including group', async () => {
+        const messageRequest: MessageRequest = {
+            id: 0,
+            title: 'Complete Notification',
+            message: 'This is a complete notification',
+            description: 'Full description',
+            creator: 123,
+            notificationGroup: NotificationGroupEnum.INACTIVE_DAYS,
+            inactiveDays: 7
+        };
+        mock.onPost('/create-bulk').reply(200, {status: UpdateStatusEnum.OK, message: 'Sent successfully'});
+
+        await notificationAPI.createBulkNotifications(messageRequest);
+
+        expect(JSON.parse(mock.history.post[0].data)).toMatchObject({
+            title: 'Complete Notification',
+            message: 'This is a complete notification',
+            description: 'Full description',
+            creator: 123,
+            notificationGroup: NotificationGroupEnum.INACTIVE_DAYS,
+            inactiveDays: 7
+        });
+    });
+
+    test('still supports sending with recipients (backward compatibility)', async () => {
+        const messageRequest: MessageRequest = {
+            id: 0,
+            title: 'Test',
+            message: 'Test message',
+            description: 'Test',
+            creator: 1,
+            recipients: [1, 2, 3]
+        };
+        mock.onPost('/create-bulk').reply(200, {status: UpdateStatusEnum.OK, message: 'Sent to 3 users'});
+
+        const result = await notificationAPI.createBulkNotifications(messageRequest);
+
+        expect(result.status).toBe(UpdateStatusEnum.OK);
+        expect(mock.history.post).toHaveLength(1);
+    });
+
+    test('still supports sending with sendAll (backward compatibility)', async () => {
+        const messageRequest: MessageRequest = {
+            id: 0,
+            title: 'Test',
+            message: 'Test message',
+            description: 'Test',
+            creator: 1,
+            sendAll: true
+        };
+        mock.onPost('/create-bulk').reply(200, {status: UpdateStatusEnum.OK, message: 'Sent to all users'});
+
+        const result = await notificationAPI.createBulkNotifications(messageRequest);
+
+        expect(result.status).toBe(UpdateStatusEnum.OK);
+    });
+
+    test('includes group and inactiveDays only when set', async () => {
+        const messageRequest: MessageRequest = {
+            id: 0,
+            title: 'Test',
+            message: 'Test',
+            description: 'Test',
+            creator: 1
+        };
+        mock.onPost('/create-bulk').reply(200, {status: UpdateStatusEnum.OK, message: 'Sent'});
+
+        await notificationAPI.createBulkNotifications(messageRequest);
+
+        expect(JSON.parse(mock.history.post[0].data)).toMatchObject({
+            title: 'Test',
+            message: 'Test',
+            description: 'Test',
+            creator: 1
+        });
+    });
+
+    test('handles response with multiple recipient counts', async () => {
+        const messageRequest: MessageRequest = {
+            id: 0,
+            title: 'Test',
+            message: 'Test',
+            description: 'Test',
+            creator: 1,
+            notificationGroup: NotificationGroupEnum.ALL_REGISTERED
+        };
+        mock.onPost('/create-bulk').reply(200, {status: UpdateStatusEnum.OK, message: 'Notification sent to 1000 users'});
+
+        const result = await notificationAPI.createBulkNotifications(messageRequest);
+
+        expect(result.message).toContain('1000');
+    });
+
+    test('handles group notification with zero days (edge case)', async () => {
+        const messageRequest: MessageRequest = {
+            id: 0,
+            title: 'Test',
+            message: 'Test',
+            description: 'Test',
+            creator: 1,
+            notificationGroup: NotificationGroupEnum.INACTIVE_DAYS,
+            inactiveDays: 0
+        };
+        mock.onPost('/create-bulk').reply(200, {status: UpdateStatusEnum.OK, message: 'Sent'});
+
+        await notificationAPI.createBulkNotifications(messageRequest);
+
+        expect(JSON.parse(mock.history.post[0].data)).toMatchObject({inactiveDays: 0});
+    });
+
+    test('handles network timeout for group notifications', async () => {
+        const messageRequest: MessageRequest = {
+            id: 0,
+            title: 'Test',
+            message: 'Test',
+            description: 'Test',
+            creator: 1,
+            notificationGroup: NotificationGroupEnum.ACTIVE_MEMBERSHIP
+        };
+        mock.onPost('/create-bulk').timeout();
+
+        await expect(notificationAPI.createBulkNotifications(messageRequest)).rejects.toThrow();
+    });
+
+    test('preserves all group enum types in API call', async () => {
+        const groupTypes = [
+            NotificationGroupEnum.ALL_REGISTERED,
+            NotificationGroupEnum.INACTIVE_DAYS,
+            NotificationGroupEnum.ACTIVE_MEMBERSHIP,
+            NotificationGroupEnum.NO_ACTIVE_MEMBERSHIP,
+            NotificationGroupEnum.LOCKED_ACCOUNTS,
+            NotificationGroupEnum.NEVER_HAD_MEMBERSHIP
+        ];
+
+        for (const group of groupTypes) {
+            mock.onPost('/create-bulk').reply(200, {status: UpdateStatusEnum.OK, message: 'Sent'});
+            const messageRequest: MessageRequest = {
+                id: 0,
+                title: 'Test',
+                message: 'Test',
+                description: 'Test',
+                creator: 1,
+                notificationGroup: group,
+                inactiveDays: group === NotificationGroupEnum.INACTIVE_DAYS ? 7 : undefined
+            };
+
+            await notificationAPI.createBulkNotifications(messageRequest);
+        }
+
+        expect(mock.history.post).toHaveLength(groupTypes.length);
     });
 });
 

--- a/src/components/DiveEvent/EditDiveEvent.tsx
+++ b/src/components/DiveEvent/EditDiveEvent.tsx
@@ -9,7 +9,6 @@ import {
     DiveTypeEnum,
     type ListUserResponse,
     type OptionItemVO,
-    PaymentTypeEnum,
     PortalConfigGroupEnum,
     RoleEnum
 } from "../../models";
@@ -21,7 +20,7 @@ import timezone from "dayjs/plugin/timezone";
 import {useSession} from "../../session";
 import {localToUTCDatetime} from "../../tools";
 import {AdminNotifications} from "../Notification";
-import {exceedsMaxParticipants, isMaxParticipantsTooLow} from "./editDiveEventValidation";
+import {buildParticipantOptions, exceedsMaxParticipants, isMaxParticipantsTooLow} from "./editDiveEventValidation";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -44,7 +43,6 @@ export function EditDiveEvent() {
     const [maxDiveLength, setMaxDiveLength] = useState<number>(120);
     const [minParticipants, setMinParticipants] = useState<number>(2);
     const [maxParticipants, setMaxParticipants] = useState<number>(20);
-    const [currentMaxParticipants, setCurrentMaxParticipants] = useState<number>(20);
     const [minEventLength, setMinEventLength] = useState<number>(1);
     const [maxEventLength, setMaxEventLength] = useState<number>(6);
     const [eventTypes, setEventTypes] = useState<{ value: string, label: string }[]>([]);
@@ -95,45 +93,10 @@ export function EditDiveEvent() {
             setOrganizerOptions(organizerList);
         }
 
-        function populateParticipantList(users: ListUserResponse[], thisEventId: number): void {
-            const participantList = [];
+        function populateParticipantList(users: ListUserResponse[], thisEventId: number, currentParticipants: ListUserResponse[] = []): void {
             const requiresMembership = getPortalConfigurationValue(PortalConfigGroupEnum.MEMBERSHIP, "event-require-membership") === "true";
             const requiresActivePayment = getPortalConfigurationValue(PortalConfigGroupEnum.PAYMENT, "event-require-payment") === "true";
-
-            for (let i = 0; i < users.length; i++) {
-                if ((requiresMembership && !users[i].membershipActive)
-                        || (requiresActivePayment && users[i].payments.length === 0)) {
-                    continue;
-                }
-
-                // Next check of the list of payments of the users are all expired or empty
-                let hasValidPayment = false;
-
-                for (let j = 0; j < users[i].payments.length; j++) {
-                    const payment = users[i].payments[j];
-                    // If the user has an active periodical payment
-                    if (payment.paymentType === PaymentTypeEnum.PERIODICAL
-                            && dayjs(payment.endDate).isAfter(dayjs())) {
-                        hasValidPayment = true;
-                        break;
-                    } else if (payment.paymentType === PaymentTypeEnum.ONE_TIME
-                            && (dayjs(payment.endDate).isAfter(dayjs())
-                                    || payment.endDate === null)
-                            && (payment.paymentCount > 0
-                                    || payment.boundEvents.includes(thisEventId))) {
-                        hasValidPayment = true;
-                        break;
-                    }
-                }
-
-                if (!hasValidPayment) {
-                    continue;
-                }
-
-                participantList.push({value: users[i].id, label: users[i].name + " (" + users[i].id + ")"});
-            }
-
-            setParticipantOptions(participantList);
+            setParticipantOptions(buildParticipantOptions(users, thisEventId, requiresMembership, requiresActivePayment, currentParticipants));
         }
 
         function getMarks(min: number, max: number, step: number, suffix: string): { [key: number]: string } {
@@ -164,7 +127,6 @@ export function EditDiveEvent() {
             const maxParticipants = parseInt(getFrontendConfigurationValue("max-participants"));
             setMinParticipants(minParticipants);
             setMaxParticipants(maxParticipants);
-            setCurrentMaxParticipants(maxParticipants);
             setParticipantsMarks(getMarks(minParticipants, maxParticipants, 5, ""));
 
             const eventTypes: string[] = getFrontendConfigurationValue("types-of-event").split(",");
@@ -201,7 +163,7 @@ export function EditDiveEvent() {
                     .then(([eventResponse, organizerResponses, participantResponses, blockedDatesResponses]) => {
                         setDiveEvent(JSON.parse(JSON.stringify(eventResponse)));
                         populateOrganizerList(organizerResponses);
-                        populateParticipantList(participantResponses, tmpDiveEventId);
+                        populateParticipantList(participantResponses, tmpDiveEventId, eventResponse.participants);
                         const dates = blockedDatesResponses.map((item: BlockedDateResponse) => dayjs(item.blockedDate).toDate());
                         setBlockedDates(dates);
                     })
@@ -529,7 +491,6 @@ export function EditDiveEvent() {
                     >
                         <Slider min={minParticipants}
                                 max={maxParticipants}
-                                defaultValue={currentMaxParticipants}
                                 step={1}
                                 marks={participantsMarks}
                         />

--- a/src/components/DiveEvent/editDiveEventValidation.ts
+++ b/src/components/DiveEvent/editDiveEventValidation.ts
@@ -1,8 +1,91 @@
+import dayjs from "dayjs";
+import {PaymentTypeEnum} from "../../models/PaymentTypeEnum";
+import type {ListUserResponse} from "../../models/responses/ListUserResponse";
+import type {OptionItemVO} from "../../models/OptionItemVO";
+
 export function isMaxParticipantsTooLow(selectedParticipantsCount: number, configuredMaxParticipants: number): boolean {
     return configuredMaxParticipants < selectedParticipantsCount;
 }
 
 export function exceedsMaxParticipants(selectedParticipantsCount: number, configuredMaxParticipants: number): boolean {
     return selectedParticipantsCount > configuredMaxParticipants;
+}
+
+function participantLabel(user: ListUserResponse): string {
+    return `${user.name} (${user.id})`;
+}
+
+/**
+ * Determines whether a user has a valid payment for a given event.
+ * A payment is valid if:
+ * - It is a PERIODICAL payment with an end date in the future, or
+ * - It is a ONE_TIME payment that has not expired (or has no end date) AND either has
+ *   remaining uses (paymentCount > 0) or is bound to the specific event.
+ */
+export function hasValidPaymentForEvent(user: ListUserResponse, eventId: number): boolean {
+    for (const payment of user.payments) {
+        if (payment.paymentType === PaymentTypeEnum.PERIODICAL
+            && dayjs(payment.endDate).isAfter(dayjs())) {
+            return true;
+        }
+
+        if (payment.paymentType === PaymentTypeEnum.ONE_TIME
+            && (dayjs(payment.endDate).isAfter(dayjs()) || payment.endDate === null)
+            && (payment.paymentCount > 0
+                || (payment.boundEvents !== null && payment.boundEvents.includes(eventId)))) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Builds the list of selectable participant options for a dive event.
+ *
+ * Users from the full user list are included when they pass the configured
+ * membership/payment requirements. Participants already enrolled in the event
+ * (`currentParticipants`) are always included regardless of those requirements —
+ * they must remain visible and selectable in the event editor.
+ */
+export function buildParticipantOptions(
+    users: ListUserResponse[],
+    eventId: number,
+    requiresMembership: boolean,
+    requiresActivePayment: boolean,
+    currentParticipants: ListUserResponse[] = []
+): OptionItemVO[] {
+    const result: OptionItemVO[] = [];
+    const includedIds = new Set<number>();
+
+    // Always include participants who are already enrolled in this event.
+    for (const participant of currentParticipants) {
+        result.push({value: participant.id, label: participantLabel(participant)});
+        includedIds.add(participant.id);
+    }
+
+    // Add additional eligible users from the full user list.
+    for (const user of users) {
+        if (includedIds.has(user.id)) {
+            continue;
+        }
+
+        if (requiresMembership && !user.membershipActive) {
+            continue;
+        }
+
+        if (requiresActivePayment && user.payments.length === 0) {
+            continue;
+        }
+
+        if (!hasValidPaymentForEvent(user, eventId)) {
+            continue;
+        }
+
+        result.push({value: user.id, label: participantLabel(user)});
+        includedIds.add(user.id);
+    }
+
+    return result;
 }
 

--- a/src/components/Notification/AdminNotifications.tsx
+++ b/src/components/Notification/AdminNotifications.tsx
@@ -1,9 +1,13 @@
 import {useEffect, useState} from "react";
-import {Button, Checkbox, Form, Input, message, Select, Space, Spin, Typography} from "antd";
+import {type RadioChangeEvent, Select} from "antd";
+import {Button, Form, Input, InputNumber, message, Radio, Select, Space, Spin, Typography} from "antd";
 import {useTranslation} from "react-i18next";
 import type {ListUserResponse, MessageRequest} from "../../models";
 import {RoleEnum, UpdateStatusEnum} from "../../models";
+import {NotificationGroupEnum, NotificationGroupLabels} from "../../models/NotificationGroupEnum";
 import {notificationAPI, userAPI} from "../../services";
+
+type NotificationMode = "sendAll" | "recipients" | "group";
 
 interface AdminNotificationsProps {
     participantIds?: number[];
@@ -16,9 +20,10 @@ export function AdminNotifications({participantIds, onNotificationSent, onCancel
     const {t} = useTranslation();
     const [loading, setLoading] = useState<boolean>(false);
     const [users, setUsers] = useState<ListUserResponse[]>([]);
-    const [sendToAll, setSendToAll] = useState<boolean>(false);
     const [notificationForm] = Form.useForm();
     const [messageApi, contextHolder] = message.useMessage();
+    const [notificationMode, setNotificationMode] = useState<NotificationMode>("recipients");
+    const [selectedGroup, setSelectedGroup] = useState<NotificationGroupEnum | undefined>();
 
     // Determine if we're in participant mode (pre-selected recipients)
     const hasParticipants = participantIds && participantIds.length > 0;
@@ -42,31 +47,62 @@ export function AdminNotifications({participantIds, onNotificationSent, onCancel
                 });
     }, [t, messageApi, hasParticipants]);
 
-    function onFinish(values: { recipients?: number[], title: string, message: string, sendAll: boolean }) {
+    function onFinish(values: {
+        recipients?: number[],
+        title: string,
+        message: string,
+        notificationMode?: NotificationMode,
+        notificationGroup?: NotificationGroupEnum,
+        inactiveDays?: number
+    }) {
         // Skip validation if we have pre-selected participants
-        if (!hasParticipants && !values.sendAll && (!values.recipients || values.recipients.length === 0)) {
-            messageApi.error(t("AdminNotifications.errorNoRecipients"));
-            return;
+        if (!hasParticipants) {
+            const mode = values.notificationMode || notificationMode;
+            if (mode === "sendAll") {
+                // sendAll is allowed for admin only (enforced by backend)
+            } else if (mode === "group") {
+                if (!values.notificationGroup) {
+                    messageApi.error(t("AdminNotifications.errorNoGroup"));
+                    return;
+                }
+                if (values.notificationGroup === NotificationGroupEnum.INACTIVE_DAYS && !values.inactiveDays) {
+                    messageApi.error(t("AdminNotifications.errorNoInactiveDays"));
+                    return;
+                }
+            } else if (!values.recipients || values.recipients.length === 0) {
+                messageApi.error(t("AdminNotifications.errorNoRecipients"));
+                return;
+            }
         }
 
         setLoading(true);
 
+        const mode = hasParticipants ? "recipients" : (values.notificationMode || notificationMode);
         const messageRequest: MessageRequest = {
             id: 0,
             description: "",
             title: values.title,
             message: values.message,
             creator: 0, // Will be set by backend
-            recipients: hasParticipants ? participantIds : (values.sendAll ? undefined : values.recipients),
-            sendAll: hasParticipants ? false : values.sendAll
         };
+
+        if (mode === "sendAll") {
+            messageRequest.sendAll = true;
+        } else if (mode === "group") {
+            messageRequest.notificationGroup = values.notificationGroup;
+            messageRequest.inactiveDays = values.inactiveDays;
+            messageRequest.sendAll = false;
+        } else {
+            messageRequest.recipients = hasParticipants ? participantIds : values.recipients;
+            messageRequest.sendAll = false;
+        }
 
         notificationAPI.createBulkNotifications(messageRequest)
                 .then((response) => {
                     if (response.status === UpdateStatusEnum.OK) {
                         messageApi.success(t("AdminNotifications.success"));
                         notificationForm.resetFields();
-                        setSendToAll(false);
+                        setNotificationMode("recipients");
                         // Call the callback if provided (e.g., to close the modal)
                         if (onNotificationSent) {
                             onNotificationSent();
@@ -83,6 +119,19 @@ export function AdminNotifications({participantIds, onNotificationSent, onCancel
                     setLoading(false);
                 });
     }
+
+    const handleModeChange = (e: RadioChangeEvent) => {
+        const value = e.target.value as NotificationMode;
+        setNotificationMode(value);
+        if (value === "sendAll") {
+            notificationForm.setFieldsValue({recipients: []});
+        } else if (value === "group") {
+            notificationForm.setFieldsValue({recipients: []});
+        } else if (value === "recipients") {
+            notificationForm.setFieldsValue({notificationGroup: undefined, inactiveDays: undefined});
+            setSelectedGroup(undefined);
+        }
+    };
 
     return (
             <div className={embedded ? "" : "darkDiv"}>
@@ -101,34 +150,26 @@ export function AdminNotifications({participantIds, onNotificationSent, onCancel
                                 layout="vertical"
                                 onFinish={onFinish}
                                 style={{maxWidth: 800}}
-                                initialValues={{sendAll: false}}
+                                initialValues={{notificationMode: "recipients"}}
                         >
                             {!hasParticipants && (
-                                    <Form.Item
-                                            name="sendAll"
-                                            valuePropName="checked"
-                                    >
-                                        <Checkbox
-                                                onChange={(e) => {
-                                                    setSendToAll(e.target.checked);
-                                                    if (e.target.checked) {
-                                                        notificationForm.setFieldsValue({recipients: []});
-                                                    }
-                                                }}
-                                        >
-                                            {t("AdminNotifications.form.sendAll.label")}
-                                        </Checkbox>
+                                    <Form.Item label={t("AdminNotifications.form.notificationMode.label")}>
+                                        <Radio.Group value={notificationMode} onChange={handleModeChange}>
+                                            <Radio value="recipients">{t("AdminNotifications.form.notificationMode.recipients")}</Radio>
+                                            <Radio value="sendAll">{t("AdminNotifications.form.notificationMode.sendAll")}</Radio>
+                                            <Radio value="group">{t("AdminNotifications.form.notificationMode.group")}</Radio>
+                                        </Radio.Group>
                                     </Form.Item>
                             )}
 
-                            {!hasParticipants && (
+                            {!hasParticipants && notificationMode === "recipients" && (
                                     <Form.Item
                                             name="recipients"
                                             label={t("AdminNotifications.form.recipients.label")}
                                             rules={[
                                                 {
                                                     validator: (_, value) => {
-                                                        if (sendToAll || (value && value.length > 0)) {
+                                                        if (value && value.length > 0) {
                                                             return Promise.resolve();
                                                         }
                                                         return Promise.reject(new Error(t("AdminNotifications.form.recipients.required")));
@@ -138,7 +179,6 @@ export function AdminNotifications({participantIds, onNotificationSent, onCancel
                                     >
                                         <Select
                                                 mode="multiple"
-                                                disabled={sendToAll}
                                                 placeholder={t("AdminNotifications.form.recipients.placeholder")}
                                                 showSearch={{optionFilterProp: "label"}}
                                                 options={users.map(user => ({
@@ -148,6 +188,43 @@ export function AdminNotifications({participantIds, onNotificationSent, onCancel
                                                 style={{width: "100%"}}
                                         />
                                     </Form.Item>
+                            )}
+
+                            {!hasParticipants && notificationMode === "group" && (
+                                    <>
+                                        <Form.Item
+                                                name="notificationGroup"
+                                                label={t("AdminNotifications.form.notificationGroup.label")}
+                                                rules={[{required: true, message: t("AdminNotifications.form.notificationGroup.required")}]}
+                                        >
+                                            <Select
+                                                    placeholder={t("AdminNotifications.form.notificationGroup.placeholder")}
+                                                    onChange={(value: NotificationGroupEnum) => setSelectedGroup(value)}
+                                                    options={Object.entries(NotificationGroupEnum).map(([, value]) => ({
+                                                        value: value,
+                                                        label: t(NotificationGroupLabels[value as NotificationGroupEnum])
+                                                    }))}
+                                                    style={{width: "100%"}}
+                                            />
+                                        </Form.Item>
+
+                                        {selectedGroup === NotificationGroupEnum.INACTIVE_DAYS && (
+                                                <Form.Item
+                                                        name="inactiveDays"
+                                                        label={t("AdminNotifications.form.inactiveDays.label")}
+                                                        rules={[
+                                                            {required: true, message: t("AdminNotifications.form.inactiveDays.required")},
+                                                            {type: "number", min: 1, message: t("AdminNotifications.form.inactiveDays.min")}
+                                                        ]}
+                                                >
+                                                    <InputNumber
+                                                            min={1}
+                                                            placeholder={t("AdminNotifications.form.inactiveDays.placeholder")}
+                                                            style={{width: "100%"}}
+                                                    />
+                                                </Form.Item>
+                                        )}
+                                    </>
                             )}
 
                             <Form.Item
@@ -179,7 +256,8 @@ export function AdminNotifications({participantIds, onNotificationSent, onCancel
                                     </Button>
                                     <Button onClick={() => {
                                         notificationForm.resetFields();
-                                        setSendToAll(false);
+                                        setNotificationMode("recipients");
+                                        setSelectedGroup(undefined);
                                         if (onCancel) {
                                             onCancel();
                                         }

--- a/src/components/Notification/AdminNotifications.tsx
+++ b/src/components/Notification/AdminNotifications.tsx
@@ -1,10 +1,8 @@
 import {useEffect, useState} from "react";
-import {type RadioChangeEvent, Select} from "antd";
-import {Button, Form, Input, InputNumber, message, Radio, Select, Space, Spin, Typography} from "antd";
+import {Button, Form, Input, InputNumber, message, Radio, type RadioChangeEvent, Select, Space, Spin, Typography} from "antd";
 import {useTranslation} from "react-i18next";
 import type {ListUserResponse, MessageRequest} from "../../models";
-import {RoleEnum, UpdateStatusEnum} from "../../models";
-import {NotificationGroupEnum, NotificationGroupLabels} from "../../models/NotificationGroupEnum";
+import {NotificationGroupEnum, NotificationGroupLabels, RoleEnum, UpdateStatusEnum} from "../../models";
 import {notificationAPI, userAPI} from "../../services";
 
 type NotificationMode = "sendAll" | "recipients" | "group";

--- a/src/models/NotificationGroupEnum.ts
+++ b/src/models/NotificationGroupEnum.ts
@@ -1,0 +1,23 @@
+/**
+ * Enumeration of user groups for notification targeting.
+ * Used to send notifications to specific categories of users based on their activity, membership, or account status.
+ */
+export const NotificationGroupEnum = {
+    ALL_REGISTERED: "all_registered",
+    INACTIVE_DAYS: "inactive_days",
+    ACTIVE_MEMBERSHIP: "active_membership",
+    NO_ACTIVE_MEMBERSHIP: "no_active_membership",
+    LOCKED_ACCOUNTS: "locked_accounts",
+    NEVER_HAD_MEMBERSHIP: "never_had_membership"
+} as const;
+
+export type NotificationGroupEnum = typeof NotificationGroupEnum[keyof typeof NotificationGroupEnum];
+
+export const NotificationGroupLabels: Record<NotificationGroupEnum, string> = {
+    [NotificationGroupEnum.ALL_REGISTERED]: "AdminNotifications.groups.all_registered",
+    [NotificationGroupEnum.INACTIVE_DAYS]: "AdminNotifications.groups.inactive_days",
+    [NotificationGroupEnum.ACTIVE_MEMBERSHIP]: "AdminNotifications.groups.active_membership",
+    [NotificationGroupEnum.NO_ACTIVE_MEMBERSHIP]: "AdminNotifications.groups.no_active_membership",
+    [NotificationGroupEnum.LOCKED_ACCOUNTS]: "AdminNotifications.groups.locked_accounts",
+    [NotificationGroupEnum.NEVER_HAD_MEMBERSHIP]: "AdminNotifications.groups.never_had_membership"
+};

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -28,6 +28,7 @@ export {DownloadTypeEnum} from "./DownloadTypeEnum";
 export {EmailNotificationTypeEnum} from "./EmailNotificationTypeEnum";
 export {MembershipStatusEnum} from "./MembershipStatusEnum";
 export {MembershipTypeEnum} from "./MembershipTypeEnum";
+export {NotificationGroupEnum, NotificationGroupLabels} from "./NotificationGroupEnum";
 export {PageStatusEnum} from "./PageStatusEnum";
 export {PaymentTypeEnum} from "./PaymentTypeEnum";
 export {PaymentExpirationTypeEnum} from "./PaymentExpirationTypeEnum";

--- a/src/models/requests/MessageRequest.ts
+++ b/src/models/requests/MessageRequest.ts
@@ -1,4 +1,5 @@
 import type {Dayjs} from "dayjs";
+import {NotificationGroupEnum} from "../NotificationGroupEnum";
 
 export interface MessageRequest {
     id: number;
@@ -9,4 +10,7 @@ export interface MessageRequest {
     createdAt?: Dayjs;
     recipients?: number[];
     sendAll?: boolean;
+    notificationGroup?: NotificationGroupEnum;
+    inactiveDays?: number;
 }
+

--- a/src/models/responses/PaymentResponse.ts
+++ b/src/models/responses/PaymentResponse.ts
@@ -9,5 +9,5 @@ export interface PaymentResponse {
     startDate: Dayjs;
     endDate: Dayjs;
     created: Dayjs;
-    boundEvents: number[];
+    boundEvents: number[] | null;
 }


### PR DESCRIPTION
This pull request expands and improves the internationalization (i18n) support for admin notifications and adds comprehensive new unit tests for participant selection and payment validation logic. The changes enhance the notification UI's flexibility and validation, and ensure robust test coverage for edge cases in event participant management.

**Internationalization improvements:**

* Added new strings and group labels for admin notifications to all supported locales (`en.json`, `de.json`, `es.json`, `fi.json`, `sv.json`), including notification group selection, inactivity days, and improved validation messages. [[1]](diffhunk://#diff-1ef07a459de08da33c9f950f32e4e739683a016d219c16503bf8c3a5e2c973c7R120-R167) [[2]](diffhunk://#diff-756dcbae1f478ea2a134d93e3d7eab916cf2ff092dd53e0da11b9a207e4bf456R120-R167) [[3]](diffhunk://#diff-555355bd18900908a3b60e81a50af72aef3df257e706db96b759307bdce9d0a4R120-R167) [[4]](diffhunk://#diff-41106f5c6eaff9273c1fa55d3a4feff75b874151af7d2288eea812f070659824R120-R167) [[5]](diffhunk://#diff-77cfcc8a1f4c6e1974650836cdf19d6ec5cd20b217a22dec71056425bfd7ee55R120-R167)

**Testing and validation enhancements:**

* Added comprehensive tests for `hasValidPaymentForEvent` and `buildParticipantOptions` in `EditDiveEventValidation.test.ts`, covering payment logic, label formatting, filtering, and regression cases to ensure correct participant option handling and robust validation. [[1]](diffhunk://#diff-b7a20df7a608aef91de589ca2fa5524400a83185154ae88361951c9a443a08cbL1-R9) [[2]](diffhunk://#diff-b7a20df7a608aef91de589ca2fa5524400a83185154ae88361951c9a443a08cbR28-R288)
* Updated test imports to include new helpers and enums required for the expanded tests.
* Updated `NotificationAPI.test.ts` to prepare for group notification testing, adding relevant enums and adjusting the test suite name for clarity.